### PR TITLE
Fix pg_readonly extension to use MODULE_PATHNAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,27 @@
 #
 # Makefile
 #
-MODULES = pg_readonly 
+MODULES = pg_readonly
 EXTENSION = pg_readonly  # the extension's name
-DATA = pg_readonly--1.0.0.sql    # script file to install
+DATA = pg_readonly--1.0.0.sql pg_readonly--1.0.4.sql
 
-# make installcheck to run automatic test
-REGRESS_OPTS =  --temp-instance=/tmp/5555 --port=5555 --temp-config pg_readonly.conf
-REGRESS = test 
+ifdef USE_PGXS
+REGRESS_OPTS = --temp-instance=/tmp/5555 --port=5555 --temp-config pg_readonly.conf
+else
+REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_readonly/pg_readonly.conf
+endif
+REGRESS = test
 
+ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/pg_readonly
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 pgxn:
 	git archive --format zip  --output ../pgxn/pg_readonly/pg_readonly-1.0.3.zip master

--- a/pg_readonly--1.0.4.sql
+++ b/pg_readonly--1.0.4.sql
@@ -4,15 +4,15 @@ DROP FUNCTION IF EXISTS unset_cluster_readonly();
 DROP FUNCTION IF EXISTS get_cluster_readonly();
 --
 CREATE FUNCTION set_cluster_readonly() RETURNS bool
- AS 'pg_readonly.so', 'pgro_set_readonly'
+ AS 'MODULE_PATHNAME', 'pgro_set_readonly'
  LANGUAGE C STRICT;
 --
 CREATE FUNCTION unset_cluster_readonly() RETURNS bool
- AS 'pg_readonly.so', 'pgro_unset_readonly'
+ AS 'MODULE_PATHNAME', 'pgro_unset_readonly'
  LANGUAGE C STRICT;
 --
 CREATE FUNCTION get_cluster_readonly() RETURNS bool
- AS 'pg_readonly.so', 'pgro_get_readonly'
+ AS 'MODULE_PATHNAME', 'pgro_get_readonly'
  LANGUAGE C STRICT;
 --
 

--- a/pg_readonly.control
+++ b/pg_readonly.control
@@ -1,5 +1,5 @@
 # pg_readonly postgresql extension
 comment = 'cluster database read only'
-default_version = '1.0.0'
+default_version = '1.0.4'
 module_pathname = '$libdir/pg_readonly'
 relocatable = false


### PR DESCRIPTION
instead of hardcoded .so suffix

Also adapt Makefile for both in-tree (make check) and PGXS builds.