### PR TITLE
Preparatory work in support of switching to XactReadOnly approach

### DIFF
--- a/expected/test.out
+++ b/expected/test.out
@@ -94,3 +94,7 @@ select * from t;
  1
 (1 row)
 
+-- Known limitation: DDL is not blocked because it goes through
+-- ProcessUtility, not ExecutorStart. A ProcessUtility_hook would be
+-- needed to cover this case.
+CREATE TABLE t2(i int);

--- a/expected/test.out
+++ b/expected/test.out
@@ -97,3 +97,14 @@ select * from t;
 -- DDL is also blocked via ProcessUtility hook
 CREATE TABLE t2(i int);
 ERROR:  pg_readonly: CREATE TABLE is not allowed because cluster is read-only
+-- DO block: INSERT inside a DO block should be blocked by the executor hook
+DO $$ BEGIN INSERT INTO t VALUES (99); END $$;
+ERROR:  pg_readonly: pgro_exec: invalid statement because cluster is read-only
+CONTEXT:  SQL statement "INSERT INTO t VALUES (99)"
+PL/pgSQL function inline_code_block line 1 at SQL statement
+select * from t;
+ i 
+---
+ 1
+(1 row)
+

--- a/expected/test.out
+++ b/expected/test.out
@@ -108,3 +108,11 @@ select * from t;
  1
 (1 row)
 
+-- Large object creation: lo_create() is a SELECT-callable function that
+-- writes to the pg_largeobject catalog internally.
+SELECT lo_create(0);
+ lo_create 
+-----------
+     16393
+(1 row)
+

--- a/expected/test.out
+++ b/expected/test.out
@@ -94,7 +94,6 @@ select * from t;
  1
 (1 row)
 
--- Known limitation: DDL is not blocked because it goes through
--- ProcessUtility, not ExecutorStart. A ProcessUtility_hook would be
--- needed to cover this case.
+-- DDL is also blocked via ProcessUtility hook
 CREATE TABLE t2(i int);
+ERROR:  pg_readonly: CREATE TABLE is not allowed because cluster is read-only

--- a/pg_readonly.c
+++ b/pg_readonly.c
@@ -59,6 +59,7 @@ static shmem_request_hook_type prev_shmem_request_hook = NULL;
 #endif
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 static ExecutorStart_hook_type prev_executor_start_hook = NULL;
+static ProcessUtility_hook_type prev_process_utility_hook = NULL;
 
 /* Links to shared memory state */
 static pgroSharedState *pgro= NULL;
@@ -74,6 +75,12 @@ static void pgro_shmem_request(void);
 static void pgro_shmem_startup(void);
 static void pgro_shmem_shutdown(int code, Datum arg);
 static void pgro_exec(QueryDesc *queryDesc, int eflags);
+static void pgro_utility(PlannedStmt *pstmt, const char *queryString,
+						 bool readOnlyTree,
+						 ProcessUtilityContext context,
+						 ParamListInfo params,
+						 QueryEnvironment *queryEnv,
+						 DestReceiver *dest, QueryCompletion *qc);
 
 static bool pgro_set_readonly_internal();
 static bool pgro_unset_readonly_internal();
@@ -387,6 +394,8 @@ _PG_init(void)
 		shmem_startup_hook = pgro_shmem_startup;
 		prev_executor_start_hook = ExecutorStart_hook;
  		ExecutorStart_hook = pgro_exec;
+		prev_process_utility_hook = ProcessUtility_hook;
+		ProcessUtility_hook = pgro_utility;
 	}
 
 	elog(DEBUG5, "pg_readonly: _PG_init(): exit");
@@ -404,6 +413,7 @@ _PG_fini(void)
 	/* Uninstall hooks. */
 	shmem_startup_hook = prev_shmem_startup_hook;
 	ExecutorStart_hook = prev_executor_start_hook;
+	ProcessUtility_hook = prev_process_utility_hook;
 
 	elog(DEBUG5, "pg_readonly: _PG_fini(): exit");
 }
@@ -462,4 +472,101 @@ pgro_exec(QueryDesc *queryDesc, int eflags)
                 (*prev_executor_start_hook)(queryDesc, eflags);
 	else	standard_ExecutorStart(queryDesc, eflags);
 
+}
+
+/*
+ * Return true if the utility command is read-only (does not modify catalog
+ * or user data).  This is a simplified version of the core's static
+ * ClassifyUtilityCommandAsReadOnly(), whitelisting only commands that are
+ * safe in a read-only environment.
+ */
+static bool
+pgro_utility_is_read_only(Node *parsetree)
+{
+	switch (nodeTag(parsetree))
+	{
+		/* Strictly read-only commands */
+		case T_AlterSystemStmt:
+		case T_CallStmt:
+		case T_CheckPointStmt:
+		case T_ClosePortalStmt:
+		case T_ConstraintsSetStmt:
+		case T_DeallocateStmt:
+		case T_DeclareCursorStmt:
+		case T_DiscardStmt:
+		case T_DoStmt:
+		case T_ExecuteStmt:
+		case T_ExplainStmt:
+		case T_FetchStmt:
+		case T_LoadStmt:
+		case T_PrepareStmt:
+		case T_UnlistenStmt:
+		case T_VariableSetStmt:
+		case T_VariableShowStmt:
+		case T_WaitStmt:
+			return true;
+
+		case T_TransactionStmt:
+			{
+				TransactionStmt *stmt = (TransactionStmt *) parsetree;
+
+				switch (stmt->kind)
+				{
+					case TRANS_STMT_BEGIN:
+					case TRANS_STMT_START:
+					case TRANS_STMT_COMMIT:
+					case TRANS_STMT_ROLLBACK:
+					case TRANS_STMT_SAVEPOINT:
+					case TRANS_STMT_RELEASE:
+					case TRANS_STMT_ROLLBACK_TO:
+					case TRANS_STMT_PREPARE:
+					case TRANS_STMT_COMMIT_PREPARED:
+					case TRANS_STMT_ROLLBACK_PREPARED:
+						return true;
+				}
+				return false;
+			}
+
+		case T_LockStmt:
+			return true;
+
+		/* COPY TO is read-only, COPY FROM is not */
+		case T_CopyStmt:
+			return !((CopyStmt *) parsetree)->is_from;
+
+		default:
+			return false;
+	}
+}
+
+/*
+ * ProcessUtility hook.
+ *
+ * Block utility commands that modify catalog or data when cluster is read-only.
+ */
+static void
+pgro_utility(PlannedStmt *pstmt, const char *queryString,
+			 bool readOnlyTree,
+			 ProcessUtilityContext context,
+			 ParamListInfo params,
+			 QueryEnvironment *queryEnv,
+			 DestReceiver *dest, QueryCompletion *qc)
+{
+	if (pgro_get_readonly_internal() &&
+		!pgro_utility_is_read_only(pstmt->utilityStmt))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_READ_ONLY_SQL_TRANSACTION),
+				 errmsg("pg_readonly: %s is not allowed because cluster is read-only",
+						CreateCommandName(pstmt->utilityStmt))));
+	}
+
+	if (prev_process_utility_hook)
+		(*prev_process_utility_hook)(pstmt, queryString, readOnlyTree,
+									 context, params, queryEnv,
+									 dest, qc);
+	else
+		standard_ProcessUtility(pstmt, queryString, readOnlyTree,
+								context, params, queryEnv,
+								dest, qc);
 }

--- a/pg_readonly.c
+++ b/pg_readonly.c
@@ -345,31 +345,30 @@ pgro_shmem_shutdown(int code, Datum arg)
 
 
 /*
- * Module load callback
+ * Module load callback.
+ *
+ * Loading via shared_preload_libraries is required to ensure that hooks
+ * are installed in every postgres process.  Without this, only the backend
+ * that called LOAD would enforce read-only mode, defeating the purpose of
+ * cluster-wide protection.
+ *
+ * process_shared_preload_libraries_in_progress is available since PG 9.4,
+ * which covers all validated versions (9.5+).
  */
 void
 _PG_init(void)
 {
 
-	const char *shared_preload_libraries_config;
-        char *pg_readonly;
-
 	elog(DEBUG5, "pg_readonly: _PG_init(): entry");
 
-	shared_preload_libraries_config = GetConfigOption("shared_preload_libraries", true, false);
-	pg_readonly = strstr(shared_preload_libraries_config, "pg_readonly");
-	if (pg_readonly == NULL)
+	if (!process_shared_preload_libraries_in_progress)
 	{
-		ereport(WARNING, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                                  errmsg("pg_readonly: pg_readonly is not loaded")));
+		ereport(WARNING,
+				(errmsg("pg_readonly must be loaded via shared_preload_libraries")));
 		pgro_enabled = false;
 	}
 	else
 		pgro_enabled = true;
-
-	if (pgro_enabled)
-		elog(LOG, "pg_readonly:_PG_init(): pg_readonly extension is enabled");
-	else	ereport(LOG, (errmsg("pg_readonly:_PG_init(): pg_readonly is not enabled")));
 
 
 	/*

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -46,7 +46,5 @@ select * from t;
 with inserted as (insert into t values(3) returning 3) select * from inserted;
 select * from t;
 
--- Known limitation: DDL is not blocked because it goes through
--- ProcessUtility, not ExecutorStart. A ProcessUtility_hook would be
--- needed to cover this case.
+-- DDL is also blocked via ProcessUtility hook
 CREATE TABLE t2(i int);

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -45,3 +45,8 @@ select * from t;
 
 with inserted as (insert into t values(3) returning 3) select * from inserted;
 select * from t;
+
+-- Known limitation: DDL is not blocked because it goes through
+-- ProcessUtility, not ExecutorStart. A ProcessUtility_hook would be
+-- needed to cover this case.
+CREATE TABLE t2(i int);

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -48,3 +48,7 @@ select * from t;
 
 -- DDL is also blocked via ProcessUtility hook
 CREATE TABLE t2(i int);
+
+-- DO block: INSERT inside a DO block should be blocked by the executor hook
+DO $$ BEGIN INSERT INTO t VALUES (99); END $$;
+select * from t;

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -52,3 +52,7 @@ CREATE TABLE t2(i int);
 -- DO block: INSERT inside a DO block should be blocked by the executor hook
 DO $$ BEGIN INSERT INTO t VALUES (99); END $$;
 select * from t;
+
+-- Large object creation: lo_create() is a SELECT-callable function that
+-- writes to the pg_largeobject catalog internally.
+SELECT lo_create(0);


### PR DESCRIPTION
Use process_shared_preload_libraries_in_progress instead of parsing the GUC string with GetConfigOption/strstr. This is the standard pattern used by PostgreSQL extensions and is available since PG 9.4, covering all supported versions.